### PR TITLE
Query component: Static StoreAPI endpoints provided as stores parameter

### DIFF
--- a/pkg/resources/query/query.go
+++ b/pkg/resources/query/query.go
@@ -124,6 +124,10 @@ func (q *Query) getStoreEndpoints() []string {
 			endpoints = append(endpoints, fmt.Sprintf("--store=%s", url))
 		}
 	}
+	// Discover static StoreAPI endpoints provided as stores parameter
+	for _, endpoint := range q.Thanos.Spec.Query.Stores {
+		endpoints = append(endpoints, fmt.Sprintf("--store=%s", endpoint))
+	}
 	return endpoints
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | NA
| License         | Apache 2.0


### What's in this PR?

Ability to add static StoreAPI addresses for query component.


### Why?

In some cases, query component need to be configured with static StoreAPI endpoints like receive (not yet in thanos operator) or other thanos installation..


### Additional context

There is stores option in thanos resource: https://github.com/banzaicloud/thanos-operator/blob/master/pkg/sdk/api/v1alpha1/thanos_types.go#L154
But is not propagated to query component arguments in deployment.


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)