### PR TITLE
fix hardcoded cluster domain for query/store/sidecar/rule discovery

### DIFF
--- a/pkg/resources/query/query.go
+++ b/pkg/resources/query/query.go
@@ -104,26 +104,26 @@ func (q *Query) getStoreEndpoints() []string {
 			if t.Spec.Query != nil {
 				reconciler := resources.NewThanosComponentReconciler(t.DeepCopy(), nil, nil, nil)
 				svc := (&Query{reconciler}).GetGRPCService()
-				endpoints = append(endpoints, fmt.Sprintf("--store=dnssrvnoa+%s", svc))
+				endpoints = append(endpoints, fmt.Sprintf("--store=dnssrvnoa+%s.%s", svc, q.Thanos.GetClusterDomain()))
 			}
 		}
 	}
 	// Discover local StoreGateway
 	if q.Thanos.Spec.StoreGateway != nil {
 		for _, u := range store.New(q.ThanosComponentReconciler).GetServiceURLS() {
-			endpoints = append(endpoints, fmt.Sprintf("--store=dnssrvnoa+%s", u))
+			endpoints = append(endpoints, fmt.Sprintf("--store=dnssrvnoa+%s.%s", u, q.Thanos.GetClusterDomain()))
 		}
 	}
 	// Discover local Rule
 	if q.Thanos.Spec.Rule != nil {
 		for _, u := range rule.New(q.ThanosComponentReconciler).GetServiceURLS() {
-			endpoints = append(endpoints, fmt.Sprintf("--store=dnssrvnoa+%s", u))
+			endpoints = append(endpoints, fmt.Sprintf("--store=dnssrvnoa+%s.%s", u, q.Thanos.GetClusterDomain()))
 		}
 	}
 	// Discover StoreEndpoint aka Sidecars
 	for _, endpoint := range q.StoreEndpoints {
 		if url := endpoint.GetServiceURL(); url != "" {
-			endpoints = append(endpoints, fmt.Sprintf("--store=%s", url))
+			endpoints = append(endpoints, fmt.Sprintf("--store=%s.%s", url, q.Thanos.GetClusterDomain()))
 		}
 	}
 	// Discover static StoreAPI endpoints provided as stores parameter

--- a/pkg/resources/query/query.go
+++ b/pkg/resources/query/query.go
@@ -16,6 +16,7 @@ package query
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
@@ -123,7 +124,13 @@ func (q *Query) getStoreEndpoints() []string {
 	// Discover StoreEndpoint aka Sidecars
 	for _, endpoint := range q.StoreEndpoints {
 		if url := endpoint.GetServiceURL(); url != "" {
-			endpoints = append(endpoints, fmt.Sprintf("--store=%s.%s", url, q.Thanos.GetClusterDomain()))
+			r, _ := regexp.Compile(`.*\.svc$`)
+			switch r.MatchString(url) {
+			case true:
+				endpoints = append(endpoints, fmt.Sprintf("--store=%s.%s", url, q.Thanos.GetClusterDomain()))
+			default:
+				endpoints = append(endpoints, fmt.Sprintf("--store=%s", url))
+			}
 		}
 	}
 	// Discover static StoreAPI endpoints provided as stores parameter

--- a/pkg/resources/rule/rule.go
+++ b/pkg/resources/rule/rule.go
@@ -78,7 +78,7 @@ func (r *ruleInstance) getMeta(suffix ...string) metav1.ObjectMeta {
 }
 
 func (r *ruleInstance) getSvc() string {
-	return fmt.Sprintf("_grpc._tcp.%s.%s.svc.cluster.local", r.getName(), r.StoreEndpoint.Namespace)
+	return fmt.Sprintf("_grpc._tcp.%s.%s.svc", r.getName(), r.StoreEndpoint.Namespace)
 }
 
 func New(reconciler *resources.ThanosComponentReconciler) *Rule {
@@ -144,7 +144,7 @@ func (r *Rule) setArgs(args []string) []string {
 	args = append(args, resources.GetArgs(rule)...)
 
 	for _, s := range r.getQueryEndpoints() {
-		url := fmt.Sprintf("--query=%s.%s.svc.cluster.local:%s", s, r.Thanos.Namespace, strconv.Itoa(int(resources.GetPort(rule.HttpAddress))))
+		url := fmt.Sprintf("--query=%s.%s.svc:%s", s, r.Thanos.Namespace, strconv.Itoa(int(resources.GetPort(rule.HttpAddress))))
 		args = append(args, url)
 	}
 

--- a/pkg/resources/store/store.go
+++ b/pkg/resources/store/store.go
@@ -58,7 +58,7 @@ func (s *storeInstance) getMeta() metav1.ObjectMeta {
 }
 
 func (s *storeInstance) getSvc() string {
-	return fmt.Sprintf("_grpc._tcp.%s.%s.svc.cluster.local", s.getName(), s.StoreEndpoint.Namespace)
+	return fmt.Sprintf("_grpc._tcp.%s.%s.svc", s.getName(), s.StoreEndpoint.Namespace)
 }
 
 func (s *Store) resourceFactory() []resources.Resource {

--- a/pkg/sdk/api/v1alpha1/storeendpoint_types.go
+++ b/pkg/sdk/api/v1alpha1/storeendpoint_types.go
@@ -71,7 +71,7 @@ func (s *StoreEndpoint) GetServiceURL() string {
 		return s.Spec.URL
 	}
 	if s.Spec.Selector != nil {
-		return fmt.Sprintf("dnssrvnoa+_grpc._tcp.%s.%s.svc.cluster.local", fmt.Sprintf("%s-%s", s.Name, SidecarName), s.Namespace)
+		return fmt.Sprintf("dnssrvnoa+_grpc._tcp.%s.%s.svc", fmt.Sprintf("%s-%s", s.Name, SidecarName), s.Namespace)
 	}
 	return ""
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #56 
| License         | Apache 2.0


### What's in this PR?
Remove hardcoded cluster domains from components code(query/store/sidecar/rule), keep it query cause looks like it is the best place to set it. 




### Additional context
Works well with and without clusterDomain specified. P.S. to get clusterDomain used the same approach as queryFrontend already uses for discovery.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

