### PR TITLE
feat(chart): allow operator image tag override

### DIFF
--- a/charts/thanos-operator/Chart.yaml
+++ b/charts/thanos-operator/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.1.0
+appVersion: 0.1.2

--- a/charts/thanos-operator/templates/deployment.yaml
+++ b/charts/thanos-operator/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/thanos-operator/values.yaml
+++ b/charts/thanos-operator/values.yaml
@@ -7,6 +7,8 @@ replicaCount: 1
 image:
   repository: banzaicloud/thanos-operator
   pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart version.
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #66
| License         | Apache 2.0


### What's in this PR?
allow overriding the default thanos-operator docker image tag. also bump the chart version

### Why?
[upstream helm has made this the default pattern when creating a new chart](https://github.com/helm/helm/pull/7878)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

