### PR TITLE
Refresh Kubernetes API versions

### DIFF
--- a/charts/thanos-operator/templates/ingress.yaml
+++ b/charts/thanos-operator/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "thanos-operator.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -34,8 +30,10 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/config/crd/patches/cainjection_in_objectstores.yaml
+++ b/config/crd/patches/cainjection_in_objectstores.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_storeendpoints.yaml
+++ b/config/crd/patches/cainjection_in_storeendpoints.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_thanos.yaml
+++ b/config/crd/patches/cainjection_in_thanos.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_objectstores.yaml
+++ b/config/crd/patches/webhook_in_objectstores.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: objectstores.monitoring.banzaicloud.io

--- a/config/crd/patches/webhook_in_storeendpoints.yaml
+++ b/config/crd/patches/webhook_in_storeendpoints.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: storeendpoints.monitoring.banzaicloud.io

--- a/config/crd/patches/webhook_in_thanos.yaml
+++ b/config/crd/patches/webhook_in_thanos.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: thanos.monitoring.banzaicloud.io

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,13 +1,13 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/controllers/objectstore_controller.go
+++ b/controllers/objectstore_controller.go
@@ -25,7 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -75,7 +75,7 @@ func (r *ObjectStoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&prometheus.ServiceMonitor{}).
-		Owns(&v1beta1.Ingress{}).
+		Owns(&netv1.Ingress{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Complete(r)
 }

--- a/controllers/storeendpoint_controller.go
+++ b/controllers/storeendpoint_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -66,6 +66,6 @@ func (r *StoreEndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.StoreEndpoint{}).
 		Owns(&corev1.Service{}).
-		Owns(&v1beta1.Ingress{}).
+		Owns(&netv1.Ingress{}).
 		Complete(r)
 }

--- a/controllers/thanos_controller.go
+++ b/controllers/thanos_controller.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -158,7 +158,7 @@ func (r *ThanosReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&prometheus.ServiceMonitor{}).
-		Owns(&v1beta1.Ingress{}).
+		Owns(&netv1.Ingress{}).
 		Owns(&appsv1.StatefulSet{}).
 		Complete(r)
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@
 # Requirements
 
 - Thanos operator requires Kubernetes v1.14.x or later.
-- For the [Helm basde installation](#deploy-thanos-operator-with-helm) you need Helm v3.0.2 or later.
+- For the [Helm based installation](#deploy-thanos-operator-with-helm) you need Helm v3.0.2 or later.
 
 
 # Deploy Thanos operator with Helm

--- a/pkg/resources/store/ingress.go
+++ b/pkg/resources/store/ingress.go
@@ -16,30 +16,32 @@ package store
 
 import (
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
-	"k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func (e *storeInstance) ingressGRPC() (runtime.Object, reconciler.DesiredState, error) {
 	if e.StoreEndpoint != nil && e.StoreEndpoint.Spec.Ingress != nil {
 		endpointIngress := e.StoreEndpoint.Spec.Ingress
-		ingress := &v1beta1.Ingress{
+		pathType := netv1.PathTypeImplementationSpecific
+		ingress := &netv1.Ingress{
 			ObjectMeta: e.StoreEndpoint.Spec.MetaOverrides.Merge(e.getMeta()),
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host: endpointIngress.Host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
-										Path: endpointIngress.Path,
-										Backend: v1beta1.IngressBackend{
-											ServiceName: e.GetName(),
-											ServicePort: intstr.IntOrString{
-												Type:   intstr.String,
-												StrVal: "grpc",
+										Path:     endpointIngress.Path,
+										PathType: &pathType,
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
+												Name: e.GetName(),
+												Port: netv1.ServiceBackendPort{
+													Name: "grpc",
+												},
 											},
 										},
 									},
@@ -51,7 +53,7 @@ func (e *storeInstance) ingressGRPC() (runtime.Object, reconciler.DesiredState, 
 			},
 		}
 		if endpointIngress.Certificate != "" {
-			ingress.Spec.TLS = []v1beta1.IngressTLS{
+			ingress.Spec.TLS = []netv1.IngressTLS{
 				{
 					Hosts:      []string{endpointIngress.Host},
 					SecretName: endpointIngress.Certificate,
@@ -60,7 +62,7 @@ func (e *storeInstance) ingressGRPC() (runtime.Object, reconciler.DesiredState, 
 		}
 		return ingress, reconciler.StatePresent, nil
 	}
-	delete := &v1beta1.Ingress{
+	delete := &netv1.Ingress{
 		ObjectMeta: e.getMeta(),
 	}
 	return delete, reconciler.StateAbsent, nil

--- a/pkg/sdk/resourcebuilder/component.go
+++ b/pkg/sdk/resourcebuilder/component.go
@@ -28,7 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -113,7 +113,7 @@ func Namespace(_ reconciler.ResourceOwner, config ComponentConfig) (runtime.Obje
 }
 
 func CRD(config *ComponentConfig, group string, kind string) (runtime.Object, reconciler.DesiredState, error) {
-	crd := &v1beta1.CustomResourceDefinition{
+	crd := &apiv1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name: fmt.Sprintf("%s.%s", kind, group),
 		},
@@ -128,7 +128,7 @@ func CRD(config *ComponentConfig, group string, kind string) (runtime.Object, re
 	}
 
 	scheme := runtime.NewScheme()
-	_ = v1beta1.AddToScheme(scheme)
+	_ = apiv1.AddToScheme(scheme)
 
 	_, _, err = serializer.NewSerializerWithOptions(serializer.DefaultMetaFactory, scheme, scheme, serializer.SerializerOptions{
 		Yaml: true,
@@ -144,7 +144,7 @@ func CRD(config *ComponentConfig, group string, kind string) (runtime.Object, re
 	crd.TypeMeta.APIVersion = ""
 
 	return crd, reconciler.DesiredStateHook(func(object runtime.Object) error {
-		current := object.(*v1beta1.CustomResourceDefinition)
+		current := object.(*apiv1.CustomResourceDefinition)
 		// simply copy the existing status over, so that we don't diff because of it
 		crd.Status = current.Status
 		return nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | yes
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
- change Ingresses to networking/v1
- change CRDs to apiextensions/v1

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The old versions are deprecated since the last three Kubernetes releases (at least).

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
