### PR TITLE
receiver: fix service labels and add common service

### DIFF
--- a/pkg/resources/receiver/receiver.go
+++ b/pkg/resources/receiver/receiver.go
@@ -83,6 +83,8 @@ func New(reconciler *resources.ReceiverReconciler) *Receiver {
 func (r *Receiver) resourceFactory() ([]resources.Resource, error) {
 	var resourceList []resources.Resource
 
+	resourceList = append(resourceList, (&receiverInstance{r, nil}).commonService)
+
 	for _, group := range r.Spec.ReceiverGroups {
 		err := mergo.Merge(&group, v1alpha1.DefaultReceiverGroup)
 		if err != nil {
@@ -116,10 +118,15 @@ func (r *Receiver) Reconcile() (*reconcile.Result, error) {
 }
 
 func (r *receiverInstance) getLabels() resources.Labels {
+	groupLabels := resources.Labels{}
+	if r.receiverGroup != nil {
+		groupLabels["receiverGroup"] = r.receiverGroup.Name
+	}
 	labels := resources.Labels{
 		resources.NameLabel: v1alpha1.ReceiverName,
 	}.Merge(
 		r.GetCommonLabels(),
+		groupLabels,
 	)
 	return labels
 }

--- a/pkg/resources/receiver/service.go
+++ b/pkg/resources/receiver/service.go
@@ -70,3 +70,44 @@ func (r *receiverInstance) service() (runtime.Object, reconciler.DesiredState, e
 	}
 	return delete, reconciler.StateAbsent, nil
 }
+
+func (r *receiverInstance) commonService() (runtime.Object, reconciler.DesiredState, error) {
+	service := &corev1.Service{
+		ObjectMeta: r.getMeta(),
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "grpc",
+					Protocol: corev1.ProtocolTCP,
+					Port:     10907,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "grpc",
+					},
+				},
+				{
+					Name:     "http",
+					Protocol: corev1.ProtocolTCP,
+					Port:     10909,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "http",
+					},
+				},
+				{
+					Name:     "remote-write",
+					Protocol: corev1.ProtocolTCP,
+					Port:     10908,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "remote-write",
+					},
+				},
+			},
+			Selector:  r.getLabels(),
+			ClusterIP: corev1.ClusterIPNone,
+			Type:      corev1.ServiceTypeClusterIP,
+		},
+	}
+	return service, reconciler.StatePresent, nil
+}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #33 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix receiver Service labels, all services had selected all pods in one receiver.
Now a common service is created for this purpose, for common ingestion, the hasring based distribution can take care of the rest. Also fixing separate services to point to the actual receiver group pods only.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
