### PR TITLE
complete remote-write prometheus spec with tenant headers

### DIFF
--- a/hack/thanos-remot-write.yaml
+++ b/hack/thanos-remot-write.yaml
@@ -1,7 +1,0 @@
-prometheus:
-  prometheusSpec:
-    image:
-      tag: v2.22.2
-
-    remoteWrite:
-      - url: http://receiver-sample-receiver:10908/api/v1/receive

--- a/hack/thanos-remote-write.yaml
+++ b/hack/thanos-remote-write.yaml
@@ -1,0 +1,13 @@
+prometheus:
+  prometheusSpec:
+    image:
+      tag: master # the headers: feature is not yet released
+
+    remoteWrite:
+      - url: http://receiver-sample-receiver:10908/api/v1/receive
+        headers:
+          THANOS-TENANT: tenant-a
+
+      - url: http://receiver-sample-receiver:10908/api/v1/receive
+        headers:
+          THANOS-TENANT: tenant-b


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/prometheus/prometheus/pull/8416
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Now that the remote_write headers feature has been merged into Prometheus, we can exercise it here in Thanos.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
