### PR TITLE
remote-write: use released prometheus which has the headers feature

### DIFF
--- a/hack/thanos-remote-write.yaml
+++ b/hack/thanos-remote-write.yaml
@@ -1,7 +1,7 @@
 prometheus:
   prometheusSpec:
     image:
-      tag: master # the headers: feature is not yet released
+      tag: v2.25.0
 
     remoteWrite:
       - url: http://receiver-sample-receiver:10908/api/v1/receive

--- a/hack/thanos-sidecar.yaml
+++ b/hack/thanos-sidecar.yaml
@@ -1,7 +1,7 @@
 prometheus:
   prometheusSpec:
     image:
-      tag: v2.22.2
+      tag: v2.25.0
 
     thanos:
       image: quay.io/thanos/thanos:v0.17.2


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #33 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
It `headers:` has been released in Prometheus.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
