### PR TITLE
samples: install prometheus operator v0.46.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,9 @@ install-minio:
 install-prometheus:
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm repo update
-	helm upgrade --install prometheus prometheus-community/kube-prometheus-stack -f hack/thanos-sidecar.yaml
+	# TODO: we need to pre-install the v0.46.0 version of the Prometheus CRD since that is the version where the headers feature got added:
+	kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.46.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+	helm upgrade --install prometheus prometheus-community/kube-prometheus-stack -f hack/thanos-remote-write.yaml
 
 install-thanos: install-minio install-prometheus
 	kubectl apply -f config/samples/

--- a/hack/thanos-remote-write.yaml
+++ b/hack/thanos-remote-write.yaml
@@ -1,3 +1,9 @@
+prometheusOperator:
+  image:
+    tag: v0.46.0
+  prometheusConfigReloaderImage:
+    tag: v0.46.0
+
 prometheus:
   prometheusSpec:
     image:


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
We need to pre-install the v0.46.0 version of the Prometheus CRD since that is the version where the headers feature got added.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)

