### PR TITLE
fix broken image links in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Open source, highly available Prometheus setup with long term storage capabiliti
 
 
 ## Architecture
-<p align="center"><img src="docs/img/Thanos-single-cluster.png" ></p>
+<p align="center"><img src="docs/img/thanos-single-cluster2.png" ></p>
 
 ## Feature highlights
 

--- a/docs/quickstarts/single_cluster_thanos.md
+++ b/docs/quickstarts/single_cluster_thanos.md
@@ -4,7 +4,7 @@
 
 # Single Cluster Thanos Install
 
-<p align="center"><img src="../img/Thanos-single-cluster2.png" ></p>
+<p align="center"><img src="../img/thanos-single-cluster2.png" ></p>
 
 
 ## Prerequisites for Thanos


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
The architecture image links at the README and Quickstart pages seem to be broken.