### PR TITLE
feat: add new production adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -5,3 +5,4 @@ This is a list of production adopters of thanos operator:
 | Company | Industry |
 | :--- | :--- |
 |[Banzai Cloud](https://banzaicloud.com)|Enterprise Technology|
+|[Shipay Tecnologia S.A.](https://shipay.com.br)|Fintech|


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | 


### What's in this PR?
Add Shipay Tecnologia as a production adoter.


### Why?
Raw kube-prometheus was not to manage unlimited data storage. As we have other banzaicloud operators in-house, thanos operator seemed like a good choice.
