### PR TITLE
Add configuration

### DIFF
--- a/controllers/config/thanosConfig.go
+++ b/controllers/config/thanosConfig.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"sync"
+
+	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
+)
+
+type ControllerConfig struct {
+	*sync.Mutex
+	Values     map[string]interface{}
+	//ThanosImage string
+	//ThanosImageTag string
+}
+
+var instance *ControllerConfig
+var once sync.Once
+
+func GetControllerConfig() *ControllerConfig {
+	once.Do(func() {
+		instance = &ControllerConfig{
+			Mutex:      &sync.Mutex{},
+			Values:     map[string]interface{}{},
+		}
+	})
+	return instance
+}
+
+func (c *ControllerConfig) AddConfigItem(key string, value interface{}) {
+	c.Lock()
+	defer c.Unlock()
+	if key != "" && value != nil && value != "" {
+		c.Values[key] = value
+	}
+}
+
+func (c *ControllerConfig) GetConfigItem(key string, defaultValue interface{}) interface{} {
+	if c.HasConfigItem(key) {
+		return c.Values[key]
+	}
+	return defaultValue
+}
+
+func (c *ControllerConfig) HasConfigItem(key string) bool {
+	c.Lock()
+	defer c.Unlock()
+	_, ok := c.Values[key]
+	return ok
+}
+
+func (c *ControllerConfig) init(){
+	c.Values["ThanosImage"] = v1alpha1.ThanosImageRepository
+	c.Values["ThanosImageTag"] = v1alpha1.ThanosImageTag
+}

--- a/controllers/config/thanosConfig.go
+++ b/controllers/config/thanosConfig.go
@@ -2,15 +2,11 @@ package config
 
 import (
 	"sync"
-
-	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
 )
 
 type ControllerConfig struct {
 	*sync.Mutex
-	Values     map[string]interface{}
-	//ThanosImage string
-	//ThanosImageTag string
+	Values map[string]interface{}
 }
 
 var instance *ControllerConfig
@@ -19,8 +15,8 @@ var once sync.Once
 func GetControllerConfig() *ControllerConfig {
 	once.Do(func() {
 		instance = &ControllerConfig{
-			Mutex:      &sync.Mutex{},
-			Values:     map[string]interface{}{},
+			Mutex:  &sync.Mutex{},
+			Values: map[string]interface{}{},
 		}
 	})
 	return instance
@@ -34,9 +30,9 @@ func (c *ControllerConfig) AddConfigItem(key string, value interface{}) {
 	}
 }
 
-func (c *ControllerConfig) GetConfigItem(key string, defaultValue interface{}) interface{} {
+func (c *ControllerConfig) GetConfigString(key string, defaultValue string) string {
 	if c.HasConfigItem(key) {
-		return c.Values[key]
+		return c.Values[key].(string)
 	}
 	return defaultValue
 }
@@ -46,9 +42,4 @@ func (c *ControllerConfig) HasConfigItem(key string) bool {
 	defer c.Unlock()
 	_, ok := c.Values[key]
 	return ok
-}
-
-func (c *ControllerConfig) init(){
-	c.Values["ThanosImage"] = v1alpha1.ThanosImageRepository
-	c.Values["ThanosImageTag"] = v1alpha1.ThanosImageTag
 }

--- a/main.go
+++ b/main.go
@@ -87,7 +87,6 @@ func main() {
 	}
 
 	controllerConfig := thanosconfig.GetControllerConfig()
-	controllerConfig.init()
 	controllerConfig.AddConfigItem("ThanosImage", flagThanosImage)
 	controllerConfig.AddConfigItem("ThanosImageTag", flagThanosImageTag)
 

--- a/main.go
+++ b/main.go
@@ -63,8 +63,8 @@ func main() {
 	flag.BoolVar(&enablePromCRDWatches, "enable-prom-crd-watches", true, "Enable dynamic watches of Prometheus CRDs")
 	flag.StringVar(&leaderElectionId, "leader-election-id", "", "The ID of the leader election")
 	flag.StringVar(&leaderElectionNamespace, "leader-election-ns", "", "The NS  of the leader election")
-	flag.StringVar(&flagThanosImage, "thanos-image", "", "Overrides the default Grafana image")
-	flag.StringVar(&flagThanosImageTag, "thanos-image-tag", "", "Overrides the default Grafana image tag")
+	flag.StringVar(&flagThanosImage, "thanos-image", "", "Overrides the default Thanos image")
+	flag.StringVar(&flagThanosImageTag, "thanos-image-tag", "", "Overrides the default Thanos image tag")
 	flag.Parse()
 
 	ctrl.SetLogger(utils.Log)

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	thanosconfig "github.com/banzaicloud/thanos-operator/controllers/config"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -52,6 +54,8 @@ func main() {
 	var enableLeaderElection, enablePromCRDWatches bool
 	var leaderElectionId string
 	var leaderElectionNamespace string
+	var flagThanosImage string
+	var flagThanosImageTag string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
@@ -59,6 +63,8 @@ func main() {
 	flag.BoolVar(&enablePromCRDWatches, "enable-prom-crd-watches", true, "Enable dynamic watches of Prometheus CRDs")
 	flag.StringVar(&leaderElectionId, "leader-election-id", "", "The ID of the leader election")
 	flag.StringVar(&leaderElectionNamespace, "leader-election-ns", "", "The NS  of the leader election")
+	flag.StringVar(&flagThanosImage, "thanos-image", "", "Overrides the default Grafana image")
+	flag.StringVar(&flagThanosImageTag, "thanos-image-tag", "", "Overrides the default Grafana image tag")
 	flag.Parse()
 
 	ctrl.SetLogger(utils.Log)
@@ -79,6 +85,11 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	controllerConfig := thanosconfig.GetControllerConfig()
+	controllerConfig.init()
+	controllerConfig.AddConfigItem("ThanosImage", flagThanosImage)
+	controllerConfig.AddConfigItem("ThanosImageTag", flagThanosImageTag)
 
 	var ThanosController, ObjectStoreController, ReceiverController controller.Controller
 

--- a/pkg/resources/bucketweb/deployment.go
+++ b/pkg/resources/bucketweb/deployment.go
@@ -25,6 +25,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/merge"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/operator-tools/pkg/utils"
+	thanosconfig "github.com/banzaicloud/thanos-operator/controllers/config"
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
 	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,6 +36,7 @@ import (
 
 func (b *BucketWeb) deployment() (runtime.Object, reconciler.DesiredState, error) {
 	meta := b.getMeta(b.getName())
+	cfg := thanosconfig.GetControllerConfig()
 	if b.ObjectStore.Spec.BucketWeb != nil {
 		bucketWeb := b.ObjectStore.Spec.BucketWeb
 		deployment := &appsv1.Deployment{
@@ -50,7 +52,7 @@ func (b *BucketWeb) deployment() (runtime.Object, reconciler.DesiredState, error
 						Containers: []corev1.Container{
 							{
 								Name:  Name,
-								Image: fmt.Sprintf("%s:%s", v1alpha1.ThanosImageRepository, v1alpha1.ThanosImageTag),
+								Image: fmt.Sprintf("%s:%s", cfg.GetConfigString("ThanosImage", v1alpha1.ThanosImageRepository), cfg.GetConfigString("ThanosImageTag", v1alpha1.ThanosImageTag)),
 								Ports: []corev1.ContainerPort{
 									{
 										Name:          "http",

--- a/pkg/resources/compactor/deployment.go
+++ b/pkg/resources/compactor/deployment.go
@@ -23,6 +23,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/merge"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/operator-tools/pkg/utils"
+	thanosconfig "github.com/banzaicloud/thanos-operator/controllers/config"
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
 	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,7 +34,7 @@ import (
 
 func (c *Compactor) deployment() (runtime.Object, reconciler.DesiredState, error) {
 	meta := c.getMeta()
-
+	cfg := thanosconfig.GetControllerConfig()
 	if c.ObjectStore.Spec.Compactor != nil {
 		compactor := c.ObjectStore.Spec.Compactor
 
@@ -50,7 +51,7 @@ func (c *Compactor) deployment() (runtime.Object, reconciler.DesiredState, error
 						Containers: []corev1.Container{
 							{
 								Name:  Name,
-								Image: fmt.Sprintf("%s:%s", v1alpha1.ThanosImageRepository, v1alpha1.ThanosImageTag),
+								Image: fmt.Sprintf("%s:%s", cfg.GetConfigString("ThanosImage", v1alpha1.ThanosImageRepository), cfg.GetConfigString("ThanosImageTag", v1alpha1.ThanosImageTag)),
 								Args: []string{
 									"compact",
 									"--log.level=info",

--- a/pkg/resources/query/deployment.go
+++ b/pkg/resources/query/deployment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/merge"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/operator-tools/pkg/utils"
+	thanosconfig "github.com/banzaicloud/thanos-operator/controllers/config"
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
 	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,6 +31,7 @@ import (
 )
 
 func (q *Query) deployment() (runtime.Object, reconciler.DesiredState, error) {
+	cfg := thanosconfig.GetControllerConfig()
 	if q.Thanos.Spec.Query != nil {
 		query := q.Thanos.Spec.Query.DeepCopy()
 
@@ -46,7 +48,7 @@ func (q *Query) deployment() (runtime.Object, reconciler.DesiredState, error) {
 						Containers: []corev1.Container{
 							{
 								Name:  "query",
-								Image: fmt.Sprintf("%s:%s", v1alpha1.ThanosImageRepository, v1alpha1.ThanosImageTag),
+								Image: fmt.Sprintf("%s:%s", cfg.GetConfigString("ThanosImage", v1alpha1.ThanosImageRepository), cfg.GetConfigString("ThanosImageTag", v1alpha1.ThanosImageTag)),
 								Args: []string{
 									"query",
 								},

--- a/pkg/resources/query_frontend/deployment.go
+++ b/pkg/resources/query_frontend/deployment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/merge"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/operator-tools/pkg/utils"
+	thanosconfig "github.com/banzaicloud/thanos-operator/controllers/config"
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
 	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,6 +31,7 @@ import (
 )
 
 func (q *QueryFrontend) deployment() (runtime.Object, reconciler.DesiredState, error) {
+	cfg := thanosconfig.GetControllerConfig()
 	if q.Thanos.Spec.QueryFrontend != nil {
 		queryFrontend := q.Thanos.Spec.QueryFrontend
 
@@ -46,7 +48,7 @@ func (q *QueryFrontend) deployment() (runtime.Object, reconciler.DesiredState, e
 						Containers: []corev1.Container{
 							{
 								Name:  "query-frontend",
-								Image: fmt.Sprintf("%s:%s", v1alpha1.ThanosImageRepository, v1alpha1.ThanosImageTag),
+								Image: fmt.Sprintf("%s:%s", cfg.GetConfigString("ThanosImage", v1alpha1.ThanosImageRepository), cfg.GetConfigString("ThanosImageTag", v1alpha1.ThanosImageTag)),
 								Args: []string{
 									"query-frontend",
 								},

--- a/pkg/resources/receiver/statefulset.go
+++ b/pkg/resources/receiver/statefulset.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/merge"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/operator-tools/pkg/utils"
+	thanosconfig "github.com/banzaicloud/thanos-operator/controllers/config"
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
 	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,6 +31,7 @@ import (
 )
 
 func (r *receiverInstance) statefulset() (runtime.Object, reconciler.DesiredState, error) {
+	cfg := thanosconfig.GetControllerConfig()
 	if r.receiverGroup != nil {
 		receiveGroup := r.receiverGroup
 
@@ -47,7 +49,7 @@ func (r *receiverInstance) statefulset() (runtime.Object, reconciler.DesiredStat
 						Containers: []corev1.Container{
 							{
 								Name:  "receive",
-								Image: fmt.Sprintf("%s:%s", v1alpha1.ThanosImageRepository, v1alpha1.ThanosImageTag),
+								Image: fmt.Sprintf("%s:%s", cfg.GetConfigString("ThanosImage", v1alpha1.ThanosImageRepository), cfg.GetConfigString("ThanosImageTag", v1alpha1.ThanosImageTag)),
 								Args: []string{
 									"receive",
 									fmt.Sprintf("--objstore.config-file=/etc/config/%s", r.receiverGroup.Config.MountFrom.SecretKeyRef.Key),

--- a/pkg/resources/rule/statefulset.go
+++ b/pkg/resources/rule/statefulset.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/merge"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/operator-tools/pkg/utils"
+	thanosconfig "github.com/banzaicloud/thanos-operator/controllers/config"
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
 	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,6 +31,7 @@ import (
 )
 
 func (r *ruleInstance) statefulset() (runtime.Object, reconciler.DesiredState, error) {
+	cfg := thanosconfig.GetControllerConfig()
 	if r.Thanos.Spec.Rule != nil {
 		rule := r.Thanos.Spec.Rule
 		statefulset := &appsv1.StatefulSet{
@@ -45,7 +47,7 @@ func (r *ruleInstance) statefulset() (runtime.Object, reconciler.DesiredState, e
 						Containers: []corev1.Container{
 							{
 								Name:  "rule",
-								Image: fmt.Sprintf("%s:%s", v1alpha1.ThanosImageRepository, v1alpha1.ThanosImageTag),
+								Image: fmt.Sprintf("%s:%s", cfg.GetConfigString("ThanosImage", v1alpha1.ThanosImageRepository), cfg.GetConfigString("ThanosImageTag", v1alpha1.ThanosImageTag)),
 								Args: []string{
 									"rule",
 									fmt.Sprintf("--objstore.config-file=/etc/config/%s", r.StoreEndpoint.Spec.Config.MountFrom.SecretKeyRef.Key),

--- a/pkg/resources/store/deployment.go
+++ b/pkg/resources/store/deployment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/merge"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/operator-tools/pkg/utils"
+	thanosconfig "github.com/banzaicloud/thanos-operator/controllers/config"
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
 	"github.com/banzaicloud/thanos-operator/pkg/sdk/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,6 +31,7 @@ import (
 )
 
 func (s *storeInstance) deployment() (runtime.Object, reconciler.DesiredState, error) {
+	cfg := thanosconfig.GetControllerConfig()
 	storeGateway := s.Store.Thanos.Spec.StoreGateway
 	if storeGateway != nil {
 		if s.StoreEndpoint.Spec.Config.MountFrom == nil {
@@ -49,7 +51,7 @@ func (s *storeInstance) deployment() (runtime.Object, reconciler.DesiredState, e
 						Containers: []corev1.Container{
 							corev1.Container{
 								Name:  v1alpha1.StoreName,
-								Image: fmt.Sprintf("%s:%s", v1alpha1.ThanosImageRepository, v1alpha1.ThanosImageTag),
+								Image: fmt.Sprintf("%s:%s", cfg.GetConfigString("ThanosImage", v1alpha1.ThanosImageRepository), cfg.GetConfigString("ThanosImageTag", v1alpha1.ThanosImageTag)),
 								Args: []string{
 									"store",
 									fmt.Sprintf("--objstore.config-file=/etc/config/%s", s.StoreEndpoint.Spec.Config.MountFrom.SecretKeyRef.Key),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Basically the idea was to override the default Thanos image and tag using an operator flag.
I've implemented this with a controller configuration, so more changes like this can be made quite easily.


### Why?
There are many reasons to not use a constant image inside the code.. for offline uses/different repository than quay.io, easy upgrades to the Thanos image that are independant of the Thanos operator image and vice versa, etc.


### Additional context
Inspired by the Grafana Operator, I've implemented this with a controller configuration. This way, more changes like this can be made very easily.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
Another nice idea would be to add image and tag fields to the CRs.
Also, more flags can be added to make this operator more configurable.
