### PR TITLE
Correction of typo in flag got query frontend

### DIFF
--- a/pkg/sdk/api/v1alpha1/thanos_types.go
+++ b/pkg/sdk/api/v1alpha1/thanos_types.go
@@ -138,7 +138,7 @@ type QueryFrontend struct {
 	// Compress HTTP responses.
 	QueryFrontendCompressResponses *bool `json:"queryFrontendCompressResponses,omitempty" thanos:"--query-frontend.compress-responses"`
 	// 	Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.
-	QueryFrontendLogQueriesLongerThan int `json:"queryFrontendLogQueriesLongerThan,omitempty" thanos:"--query-frontend.log_queries_longer_than=%d"`
+	QueryFrontendLogQueriesLongerThan int `json:"queryFrontendLogQueriesLongerThan,omitempty" thanos:"--query-frontend.log-queries-longer-than=%d"`
 	// 	Request Logging for logging the start and end of requests. LogFinishCall is enabled by default.
 	//	LogFinishCall : Logs the finish call of the requests.
 	//	LogStartAndFinishCall : Logs the start and finish call of the requests.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #144 
| License         | Apache 2.0


### What's in this PR?
Fixes typo in the flag --query-frontend.log-queries-longer-than


### Why?
To fix typo for this flag --query-frontend.log-queries-longer-than


### Additional context
Query Frontend supports --query-frontend.log-queries-longer-than flag to log queries running longer than some duration.
The flag is wrongly hardcoded in the thanos operator. _(underscore) is in place instead of -(hiphen)\


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
