### PR TITLE
Fix merge problems caused by marshaling results back into the original object

### DIFF
--- a/config/samples/monitoring_v1alpha1_thanos_override.yaml
+++ b/config/samples/monitoring_v1alpha1_thanos_override.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.banzaicloud.io/v1alpha1
+kind: Thanos
+metadata:
+  name: thanos-sample
+spec:
+  query:
+    deploymentOverrides:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: store
+              image: quay.io/thanos/thanos:v0.22.0
+              volumeMounts:
+              - mountPath: /data
+                name: pv-storage
+            volumes:
+            - name: pv-storage
+              persistentVolumeClaim:
+                claimName: storegateway-pvc

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	emperror.dev/errors v0.8.0
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/semver v1.5.0
-	github.com/banzaicloud/operator-tools v0.25.0
+	github.com/banzaicloud/operator-tools v0.25.2-0.20210929211649-76d50b1e79f6
 	github.com/banzaicloud/thanos-operator/pkg/sdk v0.0.0
 	github.com/go-logr/logr v0.4.0
 	github.com/imdario/mergo v0.3.12

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZw
 github.com/banzaicloud/k8s-objectmatcher v1.5.1 h1:u3Ic1JzIUQe0pGGjVQJvCWTNa+t9CiW49IPPovYqAss=
 github.com/banzaicloud/k8s-objectmatcher v1.5.1/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
 github.com/banzaicloud/operator-tools v0.23.0/go.mod h1:PHM11b9i4wNIpzLLDyI/dgzdfGEIRiKdUL7ltD+LkBs=
-github.com/banzaicloud/operator-tools v0.25.0 h1:PO2vtpdC5MiMt61fiaDptW37iWuTci7o8lee50JKHnY=
-github.com/banzaicloud/operator-tools v0.25.0/go.mod h1:KkeGXkPknUBJnXNNUoVz6b+DWePS38a/dwvyQjCoKcc=
+github.com/banzaicloud/operator-tools v0.25.2-0.20210929211649-76d50b1e79f6 h1:m4FzcXvt04A7mZ1eM4yiIwEvTJiwC69s8yASPKnDvQQ=
+github.com/banzaicloud/operator-tools v0.25.2-0.20210929211649-76d50b1e79f6/go.mod h1:KkeGXkPknUBJnXNNUoVz6b+DWePS38a/dwvyQjCoKcc=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	// +kubebuilder:scaffold:imports
 )
 

--- a/pkg/resources/bucketweb/deployment.go
+++ b/pkg/resources/bucketweb/deployment.go
@@ -106,9 +106,11 @@ func (b *BucketWeb) deployment() (runtime.Object, reconciler.DesiredState, error
 		deployment.Spec.Template.Spec.Containers[0].Args = containerArgs
 
 		if bucketWeb.DeploymentOverrides != nil {
-			if err := merge.Merge(deployment, bucketWeb.DeploymentOverrides); err != nil {
-				return deployment, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to deployment base object")
+			merged := &appsv1.Deployment{}
+			if err := merge.Merge(deployment, bucketWeb.DeploymentOverrides, merged); err != nil {
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to deployment base object")
 			}
+			deployment = merged
 		}
 
 		return deployment, reconciler.StatePresent, nil

--- a/pkg/resources/bucketweb/ingress.go
+++ b/pkg/resources/bucketweb/ingress.go
@@ -64,10 +64,12 @@ func (b *BucketWeb) ingress() (runtime.Object, reconciler.DesiredState, error) {
 		}
 
 		if bucketWeb.HTTPIngress.IngressOverrides != nil {
-			err := merge.Merge(ingress, bucketWeb.HTTPIngress.IngressOverrides)
+			merged := &netv1.Ingress{}
+			err := merge.Merge(ingress, bucketWeb.HTTPIngress.IngressOverrides, merged)
 			if err != nil {
-				return ingress, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to ingress base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to ingress base object")
 			}
+			ingress = merged
 		}
 
 		return ingress, reconciler.StatePresent, nil

--- a/pkg/resources/common/servicehook.go
+++ b/pkg/resources/common/servicehook.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"emperror.dev/errors"
+	"github.com/banzaicloud/operator-tools/pkg/reconciler"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func ServiceUpdateHook(service *corev1.Service) reconciler.DesiredStateHook {
+	return func(current runtime.Object) error {
+		if s, ok := current.(*corev1.Service); ok {
+			service.Spec.ClusterIP = s.Spec.ClusterIP
+		} else {
+			return errors.Errorf("failed to cast service object %+v", current)
+		}
+		return nil
+	}
+}

--- a/pkg/resources/compactor/deployment.go
+++ b/pkg/resources/compactor/deployment.go
@@ -126,9 +126,11 @@ func (c *Compactor) deployment() (runtime.Object, reconciler.DesiredState, error
 		}
 
 		if compactor.DeploymentOverrides != nil {
-			if err := merge.Merge(deployment, compactor.DeploymentOverrides); err != nil {
-				return deployment, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to deployment base object")
+			merged := &appsv1.Deployment{}
+			if err := merge.Merge(deployment, compactor.DeploymentOverrides, merged); err != nil {
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to deployment base object")
 			}
+			deployment = merged
 		}
 
 		return deployment, reconciler.StatePresent, nil

--- a/pkg/resources/query/deployment.go
+++ b/pkg/resources/query/deployment.go
@@ -78,10 +78,12 @@ func (q *Query) deployment() (runtime.Object, reconciler.DesiredState, error) {
 		deployment.Spec.Template.Spec.Containers[0].Args = q.setArgs(deployment.Spec.Template.Spec.Containers[0].Args)
 
 		if query.DeploymentOverrides != nil {
-			err := merge.Merge(deployment, query.DeploymentOverrides)
+			merged := &appsv1.Deployment{}
+			err := merge.Merge(deployment, query.DeploymentOverrides, merged)
 			if err != nil {
-				return deployment, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			deployment = merged
 		}
 
 		return deployment, reconciler.StatePresent, nil

--- a/pkg/resources/query/ingress.go
+++ b/pkg/resources/query/ingress.go
@@ -62,10 +62,12 @@ func (q *Query) ingressHTTP() (runtime.Object, reconciler.DesiredState, error) {
 		}
 
 		if q.Thanos.Spec.Query.HTTPIngress.IngressOverrides != nil {
-			err := merge.Merge(ingress, q.Thanos.Spec.Query.HTTPIngress.IngressOverrides)
+			merged := &netv1.Ingress{}
+			err := merge.Merge(ingress, q.Thanos.Spec.Query.HTTPIngress.IngressOverrides, merged)
 			if err != nil {
-				return ingress, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			ingress = merged
 		}
 
 		return ingress, reconciler.StatePresent, nil
@@ -115,10 +117,12 @@ func (q *Query) ingressGRPC() (runtime.Object, reconciler.DesiredState, error) {
 		}
 
 		if q.Thanos.Spec.Query.GRPCIngress.IngressOverrides != nil {
-			err := merge.Merge(ingress, q.Thanos.Spec.Query.GRPCIngress.IngressOverrides)
+			merged := &netv1.Ingress{}
+			err := merge.Merge(ingress, q.Thanos.Spec.Query.GRPCIngress.IngressOverrides, merged)
 			if err != nil {
 				return ingress, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			return merged, reconciler.StatePresent, nil
 		}
 
 		return ingress, reconciler.StatePresent, nil

--- a/pkg/resources/query_frontend/deployment.go
+++ b/pkg/resources/query_frontend/deployment.go
@@ -71,9 +71,11 @@ func (q *QueryFrontend) deployment() (runtime.Object, reconciler.DesiredState, e
 		deployment.Spec.Template.Spec.Containers[0].Args = q.setArgs(deployment.Spec.Template.Spec.Containers[0].Args)
 
 		if queryFrontend.DeploymentOverrides != nil {
-			if err := merge.Merge(deployment, queryFrontend.DeploymentOverrides); err != nil {
-				return deployment, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+			merged := &appsv1.Deployment{}
+			if err := merge.Merge(deployment, queryFrontend.DeploymentOverrides, merged); err != nil {
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			deployment = merged
 		}
 
 		return deployment, reconciler.StatePresent, nil

--- a/pkg/resources/query_frontend/ingress.go
+++ b/pkg/resources/query_frontend/ingress.go
@@ -64,10 +64,12 @@ func (q *QueryFrontend) ingressHTTP() (runtime.Object, reconciler.DesiredState, 
 		}
 
 		if queryFrontendIngress.IngressOverrides != nil {
-			err := merge.Merge(ingress, queryFrontendIngress.IngressOverrides)
+			merged := &netv1.Ingress{}
+			err := merge.Merge(ingress, queryFrontendIngress.IngressOverrides, merged)
 			if err != nil {
-				return ingress, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			ingress = merged
 		}
 
 		return ingress, reconciler.StatePresent, nil

--- a/pkg/resources/query_frontend/service.go
+++ b/pkg/resources/query_frontend/service.go
@@ -47,10 +47,12 @@ func (q *QueryFrontend) service() (runtime.Object, reconciler.DesiredState, erro
 		}
 
 		if queryFrontend.ServiceOverrides != nil {
-			err := merge.Merge(queryService, queryFrontend.ServiceOverrides)
+			merged := &corev1.Service{}
+			err := merge.Merge(queryService, queryFrontend.ServiceOverrides, merged)
 			if err != nil {
-				return queryService, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			queryService = merged
 		}
 
 		return queryService, reconciler.StatePresent, nil

--- a/pkg/resources/receiver.go
+++ b/pkg/resources/receiver.go
@@ -91,7 +91,7 @@ func (t *ReceiverReconciler) ReconcileResources(resourceList []Resource) (*recon
 
 func NewReceiverReconciler(receiver *v1alpha1.Receiver, genericReconciler reconciler.ResourceReconciler) *ReceiverReconciler {
 	return &ReceiverReconciler{
-		Receiver:                  receiver,
+		Receiver:           receiver,
 		ResourceReconciler: genericReconciler,
 	}
 }

--- a/pkg/resources/receiver/ingress.go
+++ b/pkg/resources/receiver/ingress.go
@@ -104,10 +104,12 @@ func (r *receiverInstance) ingressHTTP() (runtime.Object, reconciler.DesiredStat
 			}
 		}
 		if endpointIngress.IngressOverrides != nil {
-			err := merge.Merge(ingress, endpointIngress.IngressOverrides)
+			merged := &netv1.Ingress{}
+			err := merge.Merge(ingress, endpointIngress.IngressOverrides, merged)
 			if err != nil {
-				return ingress, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			ingress = merged
 		}
 
 		return ingress, reconciler.StatePresent, nil

--- a/pkg/resources/receiver/service.go
+++ b/pkg/resources/receiver/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/merge"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
+	"github.com/banzaicloud/thanos-operator/pkg/resources/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -65,12 +66,14 @@ func (r *receiverInstance) service() (runtime.Object, reconciler.DesiredState, e
 			},
 		}
 		if receiver.ServiceOverrides != nil {
-			err := merge.Merge(service, receiver.ServiceOverrides)
+			merged := &corev1.Service{}
+			err := merge.Merge(service, receiver.ServiceOverrides, merged)
 			if err != nil {
-				return service, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			service = merged
 		}
-		return service, reconciler.StatePresent, nil
+		return service, common.ServiceUpdateHook(service), nil
 	}
 	delete := &corev1.Service{
 		ObjectMeta: r.getMeta(r.receiverGroup.Name),

--- a/pkg/resources/receiver/statefulset.go
+++ b/pkg/resources/receiver/statefulset.go
@@ -160,9 +160,11 @@ func (r *receiverInstance) statefulset() (runtime.Object, reconciler.DesiredStat
 		}
 
 		if r.receiverGroup.StatefulSetOverrides != nil {
-			if err := merge.Merge(statefulset, r.receiverGroup.StatefulSetOverrides); err != nil {
-				return statefulset, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+			merged := &appsv1.StatefulSet{}
+			if err := merge.Merge(statefulset, r.receiverGroup.StatefulSetOverrides, merged); err != nil {
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			statefulset = merged
 		}
 
 		return statefulset, reconciler.StatePresent, nil

--- a/pkg/resources/rule/ingress.go
+++ b/pkg/resources/rule/ingress.go
@@ -63,10 +63,12 @@ func (r *ruleInstance) ingressHTTP() (runtime.Object, reconciler.DesiredState, e
 			}
 		}
 		if ruleIngress.IngressOverrides != nil {
-			err := merge.Merge(ingress, ruleIngress.IngressOverrides)
+			merged := &netv1.Ingress{}
+			err := merge.Merge(ingress, ruleIngress.IngressOverrides, merged)
 			if err != nil {
 				return ingress, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			return merged, reconciler.StatePresent, nil
 		}
 		return ingress, reconciler.StatePresent, nil
 	}
@@ -112,10 +114,12 @@ func (r *ruleInstance) ingressGRPC() (runtime.Object, reconciler.DesiredState, e
 			}
 		}
 		if ruleIngress.IngressOverrides != nil {
-			err := merge.Merge(ingress, ruleIngress.IngressOverrides)
+			merged := &netv1.Ingress{}
+			err := merge.Merge(ingress, ruleIngress.IngressOverrides, merged)
 			if err != nil {
-				return ingress, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			ingress = merged
 		}
 		return ingress, reconciler.StatePresent, nil
 	}

--- a/pkg/resources/rule/statefulset.go
+++ b/pkg/resources/rule/statefulset.go
@@ -123,9 +123,11 @@ func (r *ruleInstance) statefulset() (runtime.Object, reconciler.DesiredState, e
 		}
 
 		if rule.StatefulsetOverrides != nil {
-			if err := merge.Merge(statefulset, rule.StatefulsetOverrides); err != nil {
-				return statefulset, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+			merged := &appsv1.StatefulSet{}
+			if err := merge.Merge(statefulset, rule.StatefulsetOverrides, merged); err != nil {
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			statefulset = merged
 		}
 
 		return statefulset, reconciler.StatePresent, nil

--- a/pkg/resources/sidecar/ingress.go
+++ b/pkg/resources/sidecar/ingress.go
@@ -60,10 +60,12 @@ func (e *endpointService) ingressGRPC() (runtime.Object, reconciler.DesiredState
 			}
 		}
 		if endpointIngress.IngressOverrides != nil {
-			err := merge.Merge(ingress, endpointIngress.IngressOverrides)
+			merged := &netv1.Ingress{}
+			err := merge.Merge(ingress, endpointIngress.IngressOverrides, merged)
 			if err != nil {
-				return ingress, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			ingress = merged
 		}
 		return ingress, reconciler.StatePresent, nil
 	}

--- a/pkg/resources/store/deployment.go
+++ b/pkg/resources/store/deployment.go
@@ -82,9 +82,11 @@ func (s *storeInstance) deployment() (runtime.Object, reconciler.DesiredState, e
 		deployment.Spec.Template.Spec.Containers[0].Args = s.setArgs(deployment.Spec.Template.Spec.Containers[0].Args)
 
 		if storeGateway.DeploymentOverrides != nil {
-			if err := merge.Merge(deployment, storeGateway.DeploymentOverrides); err != nil {
-				return deployment, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+			merged := &appsv1.Deployment{}
+			if err := merge.Merge(deployment, storeGateway.DeploymentOverrides, merged); err != nil {
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			deployment = merged
 		}
 
 		return deployment, reconciler.StatePresent, nil

--- a/pkg/resources/store/ingress.go
+++ b/pkg/resources/store/ingress.go
@@ -60,10 +60,12 @@ func (e *storeInstance) ingressGRPC() (runtime.Object, reconciler.DesiredState, 
 			}
 		}
 		if endpointIngress.IngressOverrides != nil {
-			err := merge.Merge(ingress, endpointIngress.IngressOverrides)
+			merged := &netv1.Ingress{}
+			err := merge.Merge(ingress, endpointIngress.IngressOverrides, merged)
 			if err != nil {
-				return ingress, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			ingress = merged
 		}
 		return ingress, reconciler.StatePresent, nil
 	}

--- a/pkg/resources/store/service.go
+++ b/pkg/resources/store/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/merge"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/thanos-operator/pkg/resources"
+	"github.com/banzaicloud/thanos-operator/pkg/resources/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -56,12 +57,14 @@ func (s *storeInstance) service() (runtime.Object, reconciler.DesiredState, erro
 			},
 		}
 		if store.ServiceOverrides != nil {
-			err := merge.Merge(service, store.ServiceOverrides)
+			merged := &corev1.Service{}
+			err := merge.Merge(service, store.ServiceOverrides, merged)
 			if err != nil {
-				return service, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+				return nil, nil, errors.WrapIf(err, "unable to merge overrides to base object")
 			}
+			service = merged
 		}
-		return service, reconciler.StatePresent, nil
+		return service, common.ServiceUpdateHook(service), nil
 	}
 	delete := &corev1.Service{
 		ObjectMeta: s.getMeta(),

--- a/pkg/resources/thanosendpoint/query.go
+++ b/pkg/resources/thanosendpoint/query.go
@@ -54,9 +54,11 @@ func (r Reconciler) query() (runtime.Object, reconciler.DesiredState, error) {
 	}
 
 	if r.endpoint.Spec.QueryOverrides != nil {
-		if err := merge.Merge(query.Spec.Query, r.endpoint.Spec.QueryOverrides); err != nil {
+		merged := &v1alpha1.Query{}
+		if err := merge.Merge(query.Spec.Query, r.endpoint.Spec.QueryOverrides, merged); err != nil {
 			return nil, nil, errors.WrapIf(err, "failed to merge overrides to base query resource")
 		}
+		query.Spec.Query = merged
 	}
 
 	return query, reconciler.StatePresent, nil

--- a/pkg/resources/thanosendpoint/storeendpoint.go
+++ b/pkg/resources/thanosendpoint/storeendpoint.go
@@ -35,9 +35,11 @@ func (r Reconciler) storeEndpoint() (runtime.Object, reconciler.DesiredState, er
 	}
 
 	if r.endpoint.Spec.StoreEndpointOverrides != nil {
-		if err := merge.Merge(storeEndpoint.Spec, r.endpoint.Spec.StoreEndpointOverrides); err != nil {
+		merged := &v1alpha1.StoreEndpointSpec{}
+		if err := merge.Merge(storeEndpoint.Spec, r.endpoint.Spec.StoreEndpointOverrides, merged); err != nil {
 			return nil, nil, errors.Wrap(err, "failed to merge storeendpoint overrides")
 		}
+		storeEndpoint.Spec = *merged
 	}
 
 	return storeEndpoint, reconciler.StatePresent, nil

--- a/pkg/resources/thanospeer/query.go
+++ b/pkg/resources/thanospeer/query.go
@@ -57,9 +57,11 @@ func (r Reconciler) query(peerCert, peerCA string) resources.Resource {
 		}
 
 		if r.peer.Spec.QueryOverrides != nil {
-			if err := merge.Merge(query.Spec.Query, r.peer.Spec.QueryOverrides); err != nil {
+			merged := &v1alpha1.Query{}
+			if err := merge.Merge(query.Spec.Query, r.peer.Spec.QueryOverrides, merged); err != nil {
 				return nil, nil, errors.WrapIf(err, "failed to merge overrides to base query resource")
 			}
+			query.Spec.Query = merged
 		}
 
 		return query, reconciler.StatePresent, nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #153 
| License         | Apache 2.0


### What's in this PR?
Fixes the override mechanism, which was failing due to merging results back into the original object.

Sample yaml added that was being used for testing that the merge is now working properly for volumes and mounts in case of a thanos query deployment.