### PR TITLE
Grafana Datasource nil pointer dereference

### DIFF
--- a/pkg/resources/query/grafanadatasource.go
+++ b/pkg/resources/query/grafanadatasource.go
@@ -26,17 +26,17 @@ type strIfMap = map[string]interface{}
 
 func (q *Query) grafanaDatasource() (runtime.Object, reconciler.DesiredState, error) {
 
-	state := reconciler.StateAbsent
-	if q.Thanos.Spec.Query != nil && q.Thanos.Spec.Query.GrafanaDatasource {
-		state = reconciler.StatePresent
-	}
-
 	grafanaDatasource := unstructured.Unstructured{}
 	grafanaDatasource.SetAPIVersion("integreatly.org/v1alpha1")
 	grafanaDatasource.SetKind("GrafanaDataSource")
 
 	grafanaDatasource.SetName(q.getName())
 	grafanaDatasource.SetNamespace(q.Thanos.Namespace)
+
+	state := reconciler.StatePresent
+	if q.Thanos.Spec.Query == nil || !q.Thanos.Spec.Query.GrafanaDatasource {
+		return &grafanaDatasource, reconciler.StateAbsent, nil
+	}
 
 	grafanaDatasource.SetOwnerReferences([]metav1.OwnerReference{
 		{


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #151 
| License         | Apache 2.0


### What's in this PR?
Setup object metadata first and return with absent state instantly for the Grafana datasource, otherwise we end up with a nilpointer dereference