### PR TITLE
Remove Default context from the build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Check
           command: |
-            make check
+            make check-circle
 
   e2e-test:
     machine:
@@ -207,7 +207,6 @@ workflows:
   build:
     jobs:
       - build:
-          context: Default
           filters:
             tags:
               only: /.*/

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,30 @@
+name: License
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download license information for dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make license-cache
+
+      - name: Check licenses
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make license-check

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ license-cache: bin/licensei ## Generate license cache
 .PHONY: check
 check: check-diff lint license-check test
 
+.PHONY: check-circle
+check-circle: check-diff lint test
+
 install-minio:
 	helm repo add minio https://helm.min.io/
 	helm repo update


### PR DESCRIPTION
The "Default" context should not be required as the license check had been separated to github actions.