### PR TITLE
Cleanup tests and Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
       - checkout
       - run:
           name: Check
+          environment:
+            LINTER_FLAGS: --timeout=2m
           command: |
             make check-circle
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ object-store.yaml
 thanos-sidecar.yaml
 !hack/object-store.yaml
 !hack/thanos-sidecar.yaml
+
+.licensei.cache

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,6 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false,maxDescLen=0"
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
 LINTER_FLAGS ?= --timeout=2m
 
 GOLANGCI_VERSION = 1.35.2

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,7 @@ check: check-diff lint license-check test
 check-circle: check-diff lint test
 
 .PHONY: check-diff
-check-diff: tidy
-	$(MAKE) genall
+check-diff: genall tidy
 	git diff --exit-code
 
 .PHONY: deploy
@@ -67,7 +66,7 @@ fmt: ## Run go fmt against code
 	cd pkg/sdk && go fmt ./...
 
 .PHONY: genall
-genall: generate manifests docs
+genall: generate manifests docs tidy
 	go generate ./...
 	cd pkg/sdk && go generate ./...
 

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ list-all: ## List all make targets
 	@${MAKE} -pRrn : -f $(MAKEFILE_LIST) 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | sort
 
 .PHONY: manager
-manager: fmt generate vet ## Build manager binary
+manager: fmt generate lint ## Build manager binary
 	go build -o bin/manager main.go
 
 .PHONY: manifests
@@ -134,7 +134,7 @@ run: generate install ## Run against the configured Kubernetes cluster in ~/.kub
 	go run ./main.go
 
 .PHONY: test
-test: fmt genall lint vet ${ENVTEST_BINARY_ASSETS} ${KUBEBUILDER} ## Run tests
+test: fmt genall lint ${ENVTEST_BINARY_ASSETS} ${KUBEBUILDER} ## Run tests
 	ENVTEST_BINARY_ASSETS=${ENVTEST_BINARY_ASSETS} go test ./... -coverprofile cover.out
 	cd pkg/sdk && go test ./... -coverprofile cover-sdk.out
 
@@ -144,11 +144,6 @@ tidy: ## Run `go mod tidy` against all modules
 .PHONY: uninstall
 uninstall: manifests ## Uninstall CRDs from a cluster
 	kustomize build config/crd | kubectl delete -f -
-
-.PHONY: vet
-vet: ## Run go vet against code
-	go vet ./...
-	cd pkg/sdk && go vet ./...
 
 ## =========================
 ## ==  Tool dependencies  ==

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false,maxDescLen=0"
 
-LINTER_FLAGS ?= --timeout=2m
-
 GOLANGCI_VERSION = 1.35.2
 KUBEBUILDER_VERSION = 2.3.1
 export KUBEBUILDER_ASSETS := $(PWD)/bin

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false,maxDescLen=0"
 
+OS = $(shell go env GOOS)
+ARCH = $(shell go env GOARCH)
+
 GOLANGCI_VERSION = 1.35.2
 KUBEBUILDER_VERSION = 2.3.1
 export KUBEBUILDER_ASSETS := $(PWD)/bin
@@ -11,8 +14,6 @@ LICENSEI_VERSION = 0.2.0
 
 CONTROLLER_GEN_VERSION = v0.5.0
 CONTROLLER_GEN = $(PWD)/bin/controller-gen
-
-OS = $(shell uname | tr A-Z a-z)
 
 all: manager
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	// +kubebuilder:scaffold:imports
 )
@@ -43,9 +42,7 @@ var testEnv *envtest.Environment
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
+	RunSpecs(t, "Controller Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -48,36 +48,41 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(utils.NewLogger("ginkgo", GinkgoWriter, os.Stderr, 0))
+var _ = BeforeSuite(func() {
+	done := make(chan interface{})
+	go func() {
+		defer GinkgoRecover()
+		defer close(done)
 
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
-	}
+		logf.SetLogger(utils.NewLogger("ginkgo", GinkgoWriter, os.Stderr, 0))
 
-	var err error
-	cfg, err = testEnv.Start()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(cfg).ToNot(BeNil())
+		By("bootstrapping test environment")
+		testEnv = &envtest.Environment{
+			CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+		}
 
-	err = monitoringv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+		var err error
+		cfg, err = testEnv.Start()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg).ToNot(BeNil())
 
-	err = monitoringv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+		err = monitoringv1alpha1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
 
-	err = monitoringv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+		err = monitoringv1alpha1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+		err = monitoringv1alpha1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).ToNot(HaveOccurred())
-	Expect(k8sClient).ToNot(BeNil())
+		// +kubebuilder:scaffold:scheme
 
-	close(done)
-}, 60)
+		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(k8sClient).ToNot(BeNil())
+	}()
+	Eventually(done, 60).Should(BeClosed())
+})
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -55,7 +55,8 @@ var _ = BeforeSuite(func() {
 
 		By("bootstrapping test environment")
 		testEnv = &envtest.Environment{
-			CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+			BinaryAssetsDirectory: os.Getenv("ENVTEST_BINARY_ASSETS"),
+			CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
 		}
 
 		var err error

--- a/thanos-operator.iml
+++ b/thanos-operator.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="Go" enabled="true" />
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Remove deprecated stuff from tests and the `Makefile`, update tool versions and generally revamp the `Makefile`.

### Why?
Ginkgo deprecated a few things in v2. The resulting warnings clutter the test output.
Most tools had a pretty outdated version, and `kubebuilder` no longer publishes the `envtest` binary assets (`etcd`, `kube-apiserver`, `kubectl`) in its releases, but instead the `controller-runtime` project has a `setup-envtest` tool for managing these assets.

