### PR TITLE
Fix the bug of arguments generation

### DIFF
--- a/pkg/resources/tagparam.go
+++ b/pkg/resources/tagparam.go
@@ -17,7 +17,6 @@ package resources
 import (
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,30 +27,34 @@ func GetArgs(input interface{}) []string {
 	value := strctVal(input)
 	elements := StructElements(value)
 	for _, element := range elements {
-		var val string
+		var arg string
 		tagArgFormat, _ := parseTagWithName(element.Field.Tag.Get("thanos"))
 		if tagArgFormat != "" {
 			switch i := element.Value.Interface().(type) {
 			case v1.Duration:
 				if i.Duration != 0 {
-					val = i.String()
+					arg = fmt.Sprintf(tagArgFormat, i.String())
 				}
 			case int:
 				if i != 0 {
-					strconv.Itoa(i)
+					arg = fmt.Sprintf(tagArgFormat, i)
 				}
 			case string:
-				val = i
+				arg = fmt.Sprintf(tagArgFormat, i)
 			case bool:
 				// Bool params are switches don't need to render value
 				if i {
-					args = append(args, tagArgFormat)
+					arg = tagArgFormat
+				}
+			case *bool:
+				if *i {
+					arg = tagArgFormat
 				}
 			default:
-				val = ""
+				arg = ""
 			}
-			if val != "" {
-				args = append(args, fmt.Sprintf(tagArgFormat, val))
+			if arg != "" {
+				args = append(args, arg)
 			}
 		}
 	}

--- a/pkg/resources/tagparam_test.go
+++ b/pkg/resources/tagparam_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Test_GetArgs(t *testing.T) {
-	t.Run("Return string type value.", func(t *testing.T) {
+	t.Run("Return the arguemtn with a string type value.", func(t *testing.T) {
 		args := GetArgs(struct {
 			StringValue string `thanos:"arg=%s"`
 		}{
@@ -20,7 +20,7 @@ func Test_GetArgs(t *testing.T) {
 
 	})
 
-	t.Run("Return int type value.", func(t *testing.T) {
+	t.Run("Return the argument with an int type value.", func(t *testing.T) {
 		args := GetArgs(struct {
 			IntValue int `thanos:"arg=%d"`
 		}{
@@ -34,7 +34,7 @@ func Test_GetArgs(t *testing.T) {
 
 	})
 
-	t.Run("Return bool type value.", func(t *testing.T) {
+	t.Run("Return the argument only.", func(t *testing.T) {
 		args := GetArgs(struct {
 			BoolValue bool `thanos:"arg"`
 		}{
@@ -47,7 +47,7 @@ func Test_GetArgs(t *testing.T) {
 		}
 	})
 
-	t.Run("Return bool pointer type value.", func(t *testing.T) {
+	t.Run("Return the argument only.", func(t *testing.T) {
 		b := true
 		args := GetArgs(struct {
 			BoolValue *bool `thanos:"arg"`

--- a/pkg/resources/tagparam_test.go
+++ b/pkg/resources/tagparam_test.go
@@ -1,0 +1,63 @@
+package resources
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_GetArgs(t *testing.T) {
+	t.Run("Return string type value.", func(t *testing.T) {
+		args := GetArgs(struct {
+			StringValue string `thanos:"arg=%s"`
+		}{
+			StringValue: "val",
+		})
+
+		wanted := []string{"arg=val"}
+		if !reflect.DeepEqual(args, wanted) {
+			t.Fatalf("GetArgs != %v, wanted %v", args, wanted)
+		}
+
+	})
+
+	t.Run("Return int type value.", func(t *testing.T) {
+		args := GetArgs(struct {
+			IntValue int `thanos:"arg=%d"`
+		}{
+			IntValue: 1,
+		})
+
+		wanted := []string{"arg=1"}
+		if !reflect.DeepEqual(args, wanted) {
+			t.Fatalf("GetArgs != %v, wanted %v", args, wanted)
+		}
+
+	})
+
+	t.Run("Return bool type value.", func(t *testing.T) {
+		args := GetArgs(struct {
+			BoolValue bool `thanos:"arg"`
+		}{
+			BoolValue: true,
+		})
+
+		wanted := []string{"arg"}
+		if !reflect.DeepEqual(args, wanted) {
+			t.Fatalf("GetArgs != %v, wanted %v", args, wanted)
+		}
+	})
+
+	t.Run("Return bool pointer type value.", func(t *testing.T) {
+		b := true
+		args := GetArgs(struct {
+			BoolValue *bool `thanos:"arg"`
+		}{
+			BoolValue: &b,
+		})
+
+		wanted := []string{"arg"}
+		if !reflect.DeepEqual(args, wanted) {
+			t.Fatalf("GetArgs != %v, wanted %v", args, wanted)
+		}
+	})
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #189 
| License         | Apache 2.0


### What's in this PR?
Fix the `GetArgs` function, which generates the arguments from the custom resource.


### Why?
Fix the `GetArgs` function to handle the `int` and `*bool` type fields as the other types.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
