### PR TITLE
Fix arm64 and armv7 Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,6 +56,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository_owner }}/thanos-operator
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build thanos-operator
         uses: docker/build-push-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,13 +43,13 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Determine tag or commit
         uses: haya14busa/action-cond@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,20 +7,13 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
+env:
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+
 jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [linux/amd64,linux/arm64,linux/arm/v7]
-        include:
-          - platform: linux/amd64
-            goarch: amd64
-          - platform: linux/arm64
-            goarch: arm64
-          - platform: linux/arm/v7
-            goarch: arm
 
     steps:
       - name: Checkout code
@@ -63,9 +56,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile
-          platforms: ${{ matrix.platform }}
-          build-args: 
-            ARCH=${{ matrix.goarch }}
+          platforms: ${{ env.PLATFORMS }}
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,13 +7,21 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
-env:
-  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
-
 jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64,linux/arm64,linux/arm/v7]
+        include:
+          - platform: linux/amd64
+            goarch: amd64
+          - platform: linux/arm64
+            goarch: arm64
+          - platform: linux/arm/v7
+            goarch: arm
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -26,9 +34,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.ref }}
+          key: ${{ runner.os }}-buildx-${{ matrix.goarch }}-${{ github.ref }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-${{ matrix.goarch }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -59,7 +67,9 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ matrix.platform }}
+          args: 
+            ARCH=${{ matrix.goarch }}
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,18 +51,12 @@ jobs:
       #     username: ${{ secrets.DOCKERHUB_USERNAME }}
       #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Determine tag or commit
-        uses: haya14busa/action-cond@v1
-        id: refortag
+      - name: Docker meta for thanos-operator
+        id: thanos-operator-meta
+        uses: docker/metadata-action@v4
         with:
-          cond: ${{ startsWith(github.ref, 'refs/tags/') }}
-          if_true: ${{ github.ref }}
-          if_false: latest
-      - name: Determine image tag
-        id: imagetag
-        run: echo "::set-output name=value::${TAG_OR_BRANCH##*/}"
-        env:
-          TAG_OR_BRANCH: ${{ steps.refortag.outputs.value }}
+          images: ghcr.io/${{ github.repository_owner }}/thanos-operator
+
       - name: Build thanos-operator
         uses: docker/build-push-action@v3
         with:
@@ -73,8 +67,5 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          tags: |
-            ghcr.io/banzaicloud/thanos-operator:${{ steps.imagetag.outputs.value }}
-            banzaicloud/thanos-operator:${{ steps.imagetag.outputs.value }}
-
-
+          tags: ${{ steps.thanos-operator-meta.outputs.tags }}
+          labels: ${{ steps.thanos-operator-meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ matrix.goarch }}-${{ github.ref }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.goarch }}
+            ${{ runner.os }}-buildx-${{ matrix.goarch }}-
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -68,7 +68,7 @@ jobs:
         with:
           file: Dockerfile
           platforms: ${{ matrix.platform }}
-          args: 
+          build-args: 
             ARCH=${{ matrix.goarch }}
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build the manager binary
 FROM golang:1.17.6 as builder
 
+ARG ARCH=
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -18,7 +20,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # Build the manager binary
 FROM golang:1.17.6 as builder
 
-ARG ARCH=
-
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -20,7 +18,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #193
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR fixes go build being ran with a hard-coded value of AMD64 and also improves image metadata generation.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

ARM64 does not work right now, existing image tag generation did not use official actions.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Re-add Dockerhub pushing
